### PR TITLE
#26903 Invalid JSON-RPC request

### DIFF
--- a/lib/ansible/modules/identity/ipa/ipa_sudorule.py
+++ b/lib/ansible/modules/identity/ipa/ipa_sudorule.py
@@ -208,7 +208,7 @@ class SudoRuleIPAClient(IPAClient):
         return self.sudorule_remove_host(name=name, item={'hostgroup': item})
 
     def sudorule_add_allow_command(self, name, item):
-        return self._post_json(method='sudorule_add_allow_command', name=name, item=item)
+        return self._post_json(method='sudorule_add_allow_command', name=name, item={'sudocmd': item})
 
     def sudorule_remove_allow_command(self, name, item):
         return self._post_json(method='sudorule_remove_allow_command', name=name, item=item)


### PR DESCRIPTION
##### SUMMARY
Fixes #26903

The module ipa_sudorule has a bug where it doesn't create the correct json payload to pass to the FreeIPA API.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ipa_sudorule

##### ANSIBLE VERSION
```
[abush@localhost cluster_build]$ ansible --version
ansible 2.4.0
  config file = /home/abush/Projects/cluster_build/ansible.cfg
  configured module search path = [u'/home/abush/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]

```

##### ADDITIONAL INFORMATION
Creating a new sudorule with a list of commands results in the following error:
`fatal: [ds0.cdh-poc-cluster.internal.cdhnetwork]: FAILED! => {"changed": false, "failed": true, "msg": "repsonse sudorule_add_allow_command: Invalid JSON-RPC request: params[1] (aka options) must be a dict"}`

You can see from the FreeIPA API that it expects a nested dictionary to be passed:

```[root@ds0 ~]# ipa -vv sudorule_add_allow_command
ipa: INFO: trying https://ds0.cdh-poc-cluster.internal.cdhnetwork/ipa/json
Rule name: testrule
[member sudo command]: su -
[member sudo command group]: 
ipa: INFO: Forwarding 'sudorule_add_allow_command/1' to json server 'https://ds0.cdh-poc-cluster.internal.cdhnetwork/ipa/json'
ipa: INFO: Request: {
    "id": 0, 
    "method": "sudorule_add_allow_command/1", 
    "params": [
        [
            "testrule"
        ], 
        {
            "sudocmd": [
                "su -"
            ], 
            "version": "2.213"
        }
    ]
}
```

However only a list is passed:
https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/identity/ipa/ipa_sudorule.py#L211

Before:
```
fatal: [ds0.cdh-poc-cluster.internal.cdhnetwork]: FAILED! => {"changed": false, "failed": true, "msg": "repsonse sudorule_add_allow_command: Invalid JSON-RPC request: params[1] (aka options) must be a dict"}
```

After:
```
changed: [ds0.cdh-poc-cluster.internal.cdhnetwork] => {"changed": true, "failed": false, "sudorule": {"cn": ["deployment_sudo_su"], "dn": "ipaUniqueID=ac104364-6b01-11e7-bc01-0242ac030109,cn=sudorules,cn=sudo,dc=cdh-poc-cluster,dc=internal,dc=cdhnetwork", "ipaenabledflag": ["TRUE"], "ipauniqueid": ["ac104364-6b01-11e7-bc01-0242ac030109"], "memberhost_hostgroup": ["client_nodes"], "memberuser_group": ["deployment_users"], "objectclass": ["ipasudorule", "ipaassociation"]}}

```
